### PR TITLE
feat: テキストのみのプロンプトから画像生成をサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ A minimal Slack bot that echoes posted images as file attachments via Events API
 - Processes only when the bot is mentioned in the message (`<@bot>`), or when replying in the thread of a message that mentioned the bot.
 - Direct messages (`IM`) to the bot are always processed.
 - Also processes `app_mention` events directly.
-- If the current message has no image:
-  - If you reply with text in a thread, the bot reuses the latest bot-posted image in that thread AND any newly attached images as inputs in a single Gemini call, then posts ONE combined output image (no extra text/comment added).
-  - If no prior bot image exists, it replies with guidance.
+- If the current message has images attached, those images are used as inputs. If there is a prior bot image in the thread and a prompt is present, the bot combines the prior image and the new attachments into a single Gemini request and posts ONE output image.
+- If there are no images:
+  - If a text prompt is present, the bot now generates an image from the text-only prompt and posts it as a file (with the exact prompt as `initial_comment`).
+  - If no prompt is present, the bot replies with guidance.
 
 ## Endpoints
 


### PR DESCRIPTION
## 概要
画像の添付がなくても、テキストだけのプロンプトから Gemini で画像を生成し、Slack にファイルとして投稿できるようにしました。`initial_comment` には実際に送信したプロンプト（翻訳後を含む）がそのまま表示されます。

## 変更点
- worker: 添付画像が無い場合でも、プロンプトがあれば `generateImage` を呼び出して生成・投稿
- worker: 生成画像を `files.getUploadURLExternal` → `files.completeUploadExternal` でアップロード
- docs: README の Trigger Rules をテキストのみ対応の仕様に更新

## 動作条件
- Cloudflare Secret: `GEMINI_API_KEY` が設定されていること
- Slack App 権限・イベントは README 記載の通り

## 動作確認
- DM/チャンネルで `<@bot> 夕暮れの都市をレトロゲーム風に` のようにテキストのみ投稿 → 画像が1枚投稿され、`initial_comment` に使用プロンプトが表示されること
- 失敗時: スレッドに簡潔なエラーメッセージを投稿（`GEMINI_DEBUG=true` でデバッグJSONを添付）

## 互換性・影響
- 既存の画像編集フロー（画像添付あり）はそのまま
- 追加の設定変更は不要（SecretsがあればOK）

## スクリーンショット/ログ（任意）
- Health: `/healthz` は `{"ok":true,"env":"dev"}` を返すことを確認